### PR TITLE
Bump TS version to 4.6 to support `--target es2022`

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hans": "./dist/console.js"
   },
   "dependencies": {
-    "@types/express": "^4.16.1",
+    "@types/express": "^4.17.21",
     "@types/faker": "^4.1.5",
     "@types/morgan": "^1.7.37",
     "@types/node": "^10.14.7",
@@ -33,7 +33,7 @@
     "@types/ws": "^6.0.1",
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
-    "express": "^4.17.1",
+    "express": "^4.21.1",
     "express-graphql": "^0.8.0",
     "faker": "^4.1.0",
     "graphql": "^14.3.1",
@@ -42,17 +42,17 @@
     "reflect-metadata": "^0.1.13",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
-    "ts-node": "^7.0.1",
+    "ts-node": "^9.1.1",
     "ts-node-dev": "^1.0.0-pre.39",
-    "typescript": "^3.4.5",
+    "typescript": "4.6",
     "ws": "^6.2.1"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.13",
+    "@types/jest": "^26.0.24",
     "coveralls": "^3.0.3",
-    "jest": "^24.8.0",
+    "jest": "^26.6.3",
     "jest-when": "^2.6.0",
-    "ts-jest": "^24.0.2",
+    "ts-jest": "^26.5.6",
     "tsconfig-paths": "^3.8.0",
     "tslint": "^5.16.0"
   },


### PR DESCRIPTION
The following commands did not log any errors:
- `npm run lint`
 - `npm run test`
 - `npm run build`

Tested with Node16.