### PR TITLE
Upgrade ts-node to v10 because TS Versions higher than 4.6 are incompatible with v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "reflect-metadata": "^0.1.13",
     "socket.io": "^2.2.0",
     "socket.io-client": "^2.2.0",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.9.2",
     "ts-node-dev": "^1.0.0-pre.39",
     "typescript": "^4.6",
     "ws": "^6.2.1"


### PR DESCRIPTION
The following commands did not log any errors:
- `npm run lint`
 - `npm run test`
 - `npm run build`

Tested with Node16.